### PR TITLE
chore: update golang.org/x/text (CVE-2021-38561)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/xdg-go/stringprep
 
 go 1.11
 
-require golang.org/x/text v0.3.5
+require golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,3 @@
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
-golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Whilst xdg-go/stringprep itself is unlikely to be affected (as the CVE is in the parse done in x/text/language rather than on the normalisation codepath) it has a high CVSS scoring and can hence cause false positives in applications making use of xdg-go that pull in the older version unless they use replace directives

https://pkg.go.dev/vuln/GO-2021-0113